### PR TITLE
Use github import path

### DIFF
--- a/logfmt_encoder.go
+++ b/logfmt_encoder.go
@@ -10,7 +10,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"go.uber.org/zap"
+	"github.com/uber-go/zap"
 )
 
 const (

--- a/logfmt_encoder_test.go
+++ b/logfmt_encoder_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
-	"go.uber.org/zap/spywrite"
+	"github.com/uber-go/zap"
+	"github.com/uber-go/zap/spywrite"
 )
 
 var epoch = time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)

--- a/logfmt_options.go
+++ b/logfmt_options.go
@@ -3,7 +3,7 @@ package zaplogfmt
 import (
 	"time"
 
-	"go.uber.org/zap"
+	"github.com/uber-go/zap"
 )
 
 type LogfmtOption interface {


### PR DESCRIPTION
This package can now be used with the [zwrap](https://github.com/uber-go/zap/blob/master/zwrap/kvmap.go) package which uses the github import path