### PR TITLE
Add logfmt support for caller via EncodeCaller

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -286,6 +286,16 @@ func (enc *logfmtEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field)
 			final.AppendString(ent.Level.String())
 		}
 	}
+	if ent.Caller.Defined && final.CallerKey != "" {
+		final.addKey(final.CallerKey)
+		cur := final.buf.Len()
+		final.EncodeCaller(ent.Caller, final)
+		if cur == final.buf.Len() {
+			// User-supplied EncodeCaller was a no-op. Fall back to strings to
+			// keep output valid.
+			final.AppendString(ent.Caller.String())
+		}
+	}
 	if final.MessageKey != "" {
 		final.addKey(enc.MessageKey)
 		final.AppendString(ent.Message)


### PR DESCRIPTION
Thanks for writing the logfmt encoder for zap. This PR adds support for caller for debugging purposes.  The code was copied from https://github.com/uber-go/zap/blob/master/zapcore/json_encoder.go#L321.