### PR TITLE
Add the stacktrace as an additional field if it is present

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -305,6 +305,9 @@ func (enc *logfmtEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field)
 		final.buf.Write(enc.buf.Bytes())
 	}
 	addFields(final, fields)
+	if ent.Stack != "" && final.StacktraceKey != "" {
+		final.AddString(final.StacktraceKey, ent.Stack)
+	}
 	if final.LineEnding != "" {
 		final.buf.AppendString(final.LineEnding)
 	} else {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -149,3 +149,43 @@ func TestEncodeCaller(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "caller=h2g2.go:42 k=v\n", buf.String())
 }
+
+func TestEncodeStacktrace(t *testing.T) {
+	enc := &logfmtEncoder{buf: bufferpool.Get(), EncoderConfig: &zapcore.EncoderConfig{
+		EncodeTime:     zapcore.EpochTimeEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
+	}}
+
+	var buf *buffer.Buffer
+	var err error
+	encodeEntry := func() {
+		buf, err = enc.EncodeEntry(
+			zapcore.Entry{
+				Level:      zapcore.DebugLevel,
+				Time:       time.Time{},
+				LoggerName: "test",
+				Message:    "stacktrace test",
+				Stack: `panic: an unexpected error occurred
+
+goroutine 1 [running]:
+main.main()
+		/go/src/github.com/jsternberg/myawesomeproject/h2g2.go:4 +0x39
+`,
+			},
+			[]zapcore.Field{
+				zap.String("k", "v"),
+			},
+		)
+	}
+
+	encodeEntry()
+	assert.Nil(t, err)
+	assert.Equal(t, "k=v\n", buf.String())
+
+	enc.truncate()
+	enc.EncoderConfig.StacktraceKey = "stacktrace"
+	encodeEntry()
+	assert.Nil(t, err)
+	assert.Equal(t, `k=v stacktrace="panic: an unexpected error occurred\n\ngoroutine 1 [running]:\nmain.main()\n\t\t/go/src/github.com/jsternberg/myawesomeproject/h2g2.go:4 +0x39\n"
+`, buf.String())
+}


### PR DESCRIPTION
The stacktrace will be added the same as if it were added by
`zap.Stack("stacktrace")` and will perform the same escape sequences
that were taken from the JSON escaping code.