### PR TITLE
Avoid extra space when fields are added to encoder

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -301,7 +301,9 @@ func (enc *logfmtEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field)
 		final.AppendString(ent.Message)
 	}
 	if enc.buf.Len() > 0 {
-		final.buf.AppendByte(' ')
+		if final.buf.Len() > 0 {
+			final.buf.AppendByte(' ')
+		}
 		final.buf.Write(enc.buf.Bytes())
 	}
 	addFields(final, fields)

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -104,7 +104,7 @@ func assertOutput(t testing.TB, desc string, expected string, f func(zapcore.Enc
 	f(enc)
 	expectedPrefix := `foo=bar`
 	if expected != "" {
-		// If we expect output, it should be comma-separated from the previous
+		// If we expect output, it should be space-separated from the previous
 		// field.
 		expectedPrefix += " "
 	}
@@ -188,4 +188,26 @@ main.main()
 	assert.Nil(t, err)
 	assert.Equal(t, `k=v stacktrace="panic: an unexpected error occurred\n\ngoroutine 1 [running]:\nmain.main()\n\t\t/go/src/github.com/jsternberg/myawesomeproject/h2g2.go:4 +0x39\n"
 `, buf.String())
+}
+
+func TestEncodeEntryWithAddedField(t *testing.T) {
+	enc := &logfmtEncoder{buf: bufferpool.Get(), EncoderConfig: &zapcore.EncoderConfig{
+		EncodeTime:     zapcore.EpochTimeEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
+	}}
+	enc.AddString("x", "y")
+
+	buf, err := enc.EncodeEntry(
+		zapcore.Entry{
+			Level:      zapcore.DebugLevel,
+			Time:       time.Time{},
+			LoggerName: "test",
+			Message:    "message",
+		},
+		[]zapcore.Field{
+			zap.String("k", "v"),
+		},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "x=y k=v\n", buf.String())
 }


### PR DESCRIPTION
Avoid adding a space to an empty buffer when encoding log entries.